### PR TITLE
Add Firebase preview channel cleanup workflow

### DIFF
--- a/.github/workflows/firebase-hosting-cleanup.yml
+++ b/.github/workflows/firebase-hosting-cleanup.yml
@@ -1,6 +1,6 @@
 name: Cleanup Firebase preview channels
 
-'on':
+on:
   pull_request:
     types: [closed]
 

--- a/.github/workflows/firebase-hosting-cleanup.yml
+++ b/.github/workflows/firebase-hosting-cleanup.yml
@@ -1,0 +1,18 @@
+name: Cleanup Firebase preview channels
+
+'on':
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.0.2
+      - uses: google-github-actions/auth@v1
+        with:
+          credentials_json: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_LANDING_FARDUST }}'
+      - run: npm install -g firebase-tools
+      - run: firebase hosting:channel:delete pr-${{ github.event.pull_request.number }} --project landing-fardust
+        env:
+          FIREBASE_CLI_PREVIEWS: hostingchannels

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Welcome to the source code for **FarDust**'s personal landing page. This single 
 - Styled with TailwindCSS, Bootstrap and FontAwesome.
 - PWA ready thanks to the Angular Service Worker.
 - Continuous deployment to Firebase using GitHub Actions.
+- Merged or closed pull requests automatically remove their preview channels.
 
 ## 🛠️ Development
 


### PR DESCRIPTION
## Summary
- automatically remove preview channels for merged or closed pull requests
- document preview cleanup behavior in README

## Testing
- `bash node_modules/pre-commit/hook`

------
https://chatgpt.com/codex/tasks/task_e_684224c9efb08325be9ea8fa02f4737b