### PR TITLE
Add Node 22 setup in Firebase workflows

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3.0.2
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '22'
           cache: 'npm'
       - run: npm ci --also=dev && npm run build
       - uses: FirebaseExtended/action-hosting-deploy@v0

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.0.2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
       - run: npm ci --also=dev && npm run build
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -8,6 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.0.2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
       - run: npm ci && npm run build
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3.0.2
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '22'
           cache: 'npm'
       - run: npm ci && npm run build
       - uses: FirebaseExtended/action-hosting-deploy@v0


### PR DESCRIPTION
## Summary
- use `actions/setup-node@v3` with Node 22 and npm cache for merge workflow
- use `actions/setup-node@v3` with Node 22 and npm cache for pull-request workflow

## Testing
- `node --version`
- `npm ci --prefer-offline --no-audit --silent` *(fails: command interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68421e9601f88325890b1a004ca2cf60