### PR TITLE
Auto-load personal section

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ ng build --configuration production
 npm run deploy      # Deploy to Firebase
 ```
 
+### Personal section
+
+Set `personalInfoUrl` in `src/environments/environment.ts` to the Cloud Run
+endpoint that returns your private bio. The personal section shows a short
+public summary by default and automatically fetches additional details when a
+valid token is available. The token will be sent as a `token` query parameter
+(e.g. `?token=YOUR_TOKEN`) and persisted in a `personal_token` cookie so you
+don't have to re-enter it.
+
 ## 📚 Learn More
 
 Check the source code for examples of Angular modules, components and RxJS usage. Feel free to explore the project and modify it to suit your own portfolio! 💻

--- a/src/app/home/home.module.ts
+++ b/src/app/home/home.module.ts
@@ -3,6 +3,8 @@ import { CommonModule } from '@angular/common';
 import { ConsoleModule } from '../common/console/console.module';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { HttpClientModule } from '@angular/common/http';
+import { FormsModule } from '@angular/forms';
+import { PersonalInfoComponent } from './personal-info/personal-info.component';
 import { HomeComponent } from './home.component';
 import { InfoComponent } from './info/info.component';
 import { HomeRoutingModule } from './home-routing.module';
@@ -13,13 +15,15 @@ import { HomeRoutingModule } from './home-routing.module';
   declarations: [
     HomeComponent,
     InfoComponent,
+    PersonalInfoComponent,
   ],
   imports: [
     CommonModule,
     HomeRoutingModule,
     HttpClientModule,
     ConsoleModule,
-    FontAwesomeModule
+    FontAwesomeModule,
+    FormsModule
   ]
 })
 export class HomeModule { }

--- a/src/app/home/info/info.component.html
+++ b/src/app/home/info/info.component.html
@@ -51,6 +51,7 @@
                 </li>
               </ul>
             </div>
+            <app-personal-info class="mt-4"></app-personal-info>
           </div>
         </div>
       </div>

--- a/src/app/home/personal-info/personal-info.component.html
+++ b/src/app/home/personal-info/personal-info.component.html
@@ -1,8 +1,5 @@
 <div class="personal-info my-4">
   <p class="mb-4 whitespace-pre-line">{{ publicBio }}</p>
-  <div class="mb-2">
-    <input type="password" [(ngModel)]="token" (ngModelChange)="tokenChanged()" placeholder="Access token" class="border p-1 mr-2">
-  </div>
   <p *ngIf="error" class="text-red-600">{{ error }}</p>
   <div *ngIf="personal$ | async as personal" class="mt-2 whitespace-pre-line">{{ personal.privateBio }}</div>
 </div>

--- a/src/app/home/personal-info/personal-info.component.html
+++ b/src/app/home/personal-info/personal-info.component.html
@@ -1,0 +1,8 @@
+<div class="personal-info my-4">
+  <p class="mb-4 whitespace-pre-line">{{ publicBio }}</p>
+  <div class="mb-2">
+    <input type="password" [(ngModel)]="token" (ngModelChange)="tokenChanged()" placeholder="Access token" class="border p-1 mr-2">
+  </div>
+  <p *ngIf="error" class="text-red-600">{{ error }}</p>
+  <div *ngIf="personal$ | async as personal" class="mt-2 whitespace-pre-line">{{ personal.privateBio }}</div>
+</div>

--- a/src/app/home/personal-info/personal-info.component.sass
+++ b/src/app/home/personal-info/personal-info.component.sass
@@ -1,0 +1,4 @@
+.personal-info
+  max-width: 600px
+  margin-left: auto
+  margin-right: auto

--- a/src/app/home/personal-info/personal-info.component.spec.ts
+++ b/src/app/home/personal-info/personal-info.component.spec.ts
@@ -1,0 +1,48 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { PersonalInfoComponent } from './personal-info.component';
+
+describe('PersonalInfoComponent', () => {
+  let component: PersonalInfoComponent;
+  let fixture: ComponentFixture<PersonalInfoComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FormsModule, HttpClientTestingModule],
+      declarations: [PersonalInfoComponent]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    document.cookie = 'personal_token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+    fixture = TestBed.createComponent(PersonalInfoComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should have public bio defined', () => {
+    expect(component.publicBio.length).toBeGreaterThan(0);
+  });
+
+  it('should load token from cookie and call load', () => {
+    document.cookie = 'personal_token=cookieTok';
+    fixture = TestBed.createComponent(PersonalInfoComponent);
+    component = fixture.componentInstance;
+    spyOn(component, 'load');
+    fixture.detectChanges();
+    expect(component.token).toBe('cookieTok');
+    expect(component.load).toHaveBeenCalled();
+  });
+
+  it('should store token in cookie when changed', () => {
+    component.token = 'saveTok';
+    component.tokenChanged();
+    expect(document.cookie).toContain('personal_token=saveTok');
+  });
+});

--- a/src/app/home/personal-info/personal-info.component.ts
+++ b/src/app/home/personal-info/personal-info.component.ts
@@ -1,0 +1,51 @@
+import { Component, OnInit } from '@angular/core';
+import { PersonalInfoService, PrivateInfo } from '../../services/personal-info.service';
+import { Observable, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+const TOKEN_COOKIE = 'personal_token';
+
+@Component({
+  selector: 'app-personal-info',
+  templateUrl: './personal-info.component.html',
+  styleUrls: ['./personal-info.component.sass']
+})
+
+export class PersonalInfoComponent implements OnInit {
+  token = '';
+  personal$?: Observable<PrivateInfo>;
+  error = '';
+  readonly publicBio =
+    'Soy una persona curiosa y enérgica. Reparto mi tiempo entre trabajar, entrenar y disfrutar de los videojuegos. ' +
+    'Viajar solo me permite observar cómo funcionan las cosas en distintos lugares, siempre acompañado de mi gato y buenos amigos.';
+
+  constructor(private personalService: PersonalInfoService) {}
+
+  ngOnInit(): void {
+    const match = document.cookie.match(new RegExp('(?:^|; )' + TOKEN_COOKIE + '=([^;]*)'));
+    this.token = match ? decodeURIComponent(match[1]) : '';
+    if (this.token) {
+      this.load();
+    }
+  }
+
+  tokenChanged(): void {
+    if (!this.token) {
+      document.cookie = `${TOKEN_COOKIE}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+      this.personal$ = undefined;
+      return;
+    }
+    this.load();
+  }
+
+  load(): void {
+    this.error = '';
+    document.cookie = `${TOKEN_COOKIE}=${encodeURIComponent(this.token)}; path=/`;
+    this.personal$ = this.personalService.getPersonalInfo(this.token).pipe(
+      catchError(() => {
+        this.error = 'Could not load personal info';
+        return of({ privateBio: '' });
+      })
+    );
+  }
+}

--- a/src/app/services/personal-info.service.spec.ts
+++ b/src/app/services/personal-info.service.spec.ts
@@ -1,0 +1,34 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { PersonalInfoService, PrivateInfo } from './personal-info.service';
+import { environment } from '../../environments/environment';
+
+describe('PersonalInfoService', () => {
+  let service: PersonalInfoService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
+    service = TestBed.inject(PersonalInfoService);
+    httpMock = TestBed.inject(HttpTestingController);
+    (environment as any).personalInfoUrl = '/info';
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should fetch private info', () => {
+    const mock: PrivateInfo = { privateBio: 'secret' };
+    service.getPersonalInfo('tok').subscribe(data => {
+      expect(data).toEqual(mock);
+    });
+    const req = httpMock.expectOne('/info?token=tok');
+    expect(req.request.params.get('token')).toBe('tok');
+    expect(req.request.headers.has('Authorization')).toBeFalse();
+    req.flush(mock);
+    httpMock.verify();
+  });
+});

--- a/src/app/services/personal-info.service.ts
+++ b/src/app/services/personal-info.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+export interface PrivateInfo {
+  privateBio: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PersonalInfoService {
+  constructor(private http: HttpClient) {}
+
+  getPersonalInfo(token: string): Observable<PrivateInfo> {
+    const params = new HttpParams().set('token', token);
+    return this.http.get<PrivateInfo>(environment.personalInfoUrl, { params });
+  }
+}

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: true,
-  githubUser: 'FarDust'
+  githubUser: 'FarDust',
+  personalInfoUrl: ''
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,7 +4,8 @@
 
 export const environment = {
   production: false,
-  githubUser: 'FarDust'
+  githubUser: 'FarDust',
+  personalInfoUrl: ''
 };
 
 /*


### PR DESCRIPTION
## Summary
- remove the "Cargar más" button and trigger loading when the token changes
- automatically load personal info on init if a saved token exists
- update unit tests for new behavior
- clarify README about automatic loading

## Testing
- `npm test -- --watch=false`


------
https://chatgpt.com/codex/tasks/task_e_68421de6890c83258b7a3dbd77260f24