### PR TITLE
Improve unit tests and coverage

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -9,16 +9,11 @@ module.exports = function (config) {
       require('karma-jasmine'),
       require('karma-chrome-launcher'),
       require('karma-jasmine-html-reporter'),
-      require('karma-coverage-istanbul-reporter'),
+      require('karma-coverage'),
       require('@angular-devkit/build-angular/plugins/karma')
     ],
     client: {
       clearContext: false // leave Jasmine Spec Runner output visible in browser
-    },
-    coverageIstanbulReporter: {
-      dir: require('path').join(__dirname, './coverage/landing-fardust'),
-      reports: ['html', 'lcovonly', 'text-summary'],
-      fixWebpackSourcePaths: true
     },
     customLaunchers: {
       ChromeHeadlessNoSandbox: {
@@ -26,7 +21,7 @@ module.exports = function (config) {
         flags: ['--no-sandbox']
       }
     },
-    reporters: ['progress', 'kjhtml'],
+    reporters: ['progress', 'kjhtml', 'coverage'],
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "jasmine-spec-reporter": "~7.0.0",
         "karma": "~6.4.0",
         "karma-chrome-launcher": "~3.1.0",
+        "karma-coverage": "~2.2.0",
         "karma-coverage-istanbul-reporter": "~3.0.2",
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "^2.0.0",
@@ -9640,6 +9641,24 @@
         "which": "bin/which"
       }
     },
+    "node_modules/karma-coverage": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/karma-coverage/-/karma-coverage-2.2.1.tgz",
+      "integrity": "sha512-yj7hbequkQP2qOSb20GuNSIyE//PgJWHwC2IydLE6XRtsnaflv+/OSGNssPjobYUlhVVagy99TQpqUt3vAUG7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.2.0",
+        "istanbul-lib-instrument": "^5.1.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.1",
+        "istanbul-reports": "^3.0.5",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/karma-coverage-istanbul-reporter": {
       "version": "3.0.3",
       "dev": true,
@@ -9673,6 +9692,55 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/karma-coverage/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/karma-coverage/node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/karma-coverage/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/karma-coverage/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/karma-jasmine": {
@@ -22200,6 +22268,58 @@
           "requires": {
             "isexe": "^2.0.0"
           }
+        }
+      }
+    },
+    "karma-coverage": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/karma-coverage/-/karma-coverage-2.2.1.tgz",
+      "integrity": "sha512-yj7hbequkQP2qOSb20GuNSIyE//PgJWHwC2IydLE6XRtsnaflv+/OSGNssPjobYUlhVVagy99TQpqUt3vAUG7A==",
+      "dev": true,
+      "requires": {
+        "istanbul-lib-coverage": "^3.2.0",
+        "istanbul-lib-instrument": "^5.1.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.1",
+        "istanbul-reports": "^3.0.5",
+        "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "istanbul-lib-source-maps": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+          "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.1",
+            "istanbul-lib-coverage": "^3.0.0",
+            "source-map": "^0.6.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "jasmine-spec-reporter": "~7.0.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.1.0",
+    "karma-coverage": "~2.2.0",
     "karma-coverage-istanbul-reporter": "~3.0.2",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "^2.0.0",

--- a/src/app/common/console/console.component.spec.ts
+++ b/src/app/common/console/console.component.spec.ts
@@ -9,12 +9,15 @@ describe('ConsoleComponent', () => {
   let component: ConsoleComponent;
   let fixture: ComponentFixture<ConsoleComponent>;
 
+  let checkIPSpy: jasmine.Spy;
+
   beforeEach(async () => {
+    checkIPSpy = jasmine.createSpy('checkIP');
     await TestBed.configureTestingModule({
       declarations: [ ConsoleComponent ],
       imports: [HttpClientTestingModule],
       providers: [
-        { provide: CountryService, useValue: { checkIP: () => {}, subscribe: () => ({unsubscribe() {}}) } }
+        { provide: CountryService, useValue: { checkIP: checkIPSpy, subscribe: () => ({unsubscribe() {}}) } }
       ],
       schemas: [NO_ERRORS_SCHEMA]
     })
@@ -27,5 +30,9 @@ describe('ConsoleComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should request IP on init', () => {
+    expect(checkIPSpy).toHaveBeenCalledWith('');
   });
 });

--- a/src/app/experience/viewer/viewer.component.spec.ts
+++ b/src/app/experience/viewer/viewer.component.spec.ts
@@ -22,4 +22,32 @@ describe('ViewerComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should set total pages on PDF load', () => {
+    component.onPdfLoad({ numPages: 5 } as any);
+    expect(component.totalPages).toBe(5);
+  });
+
+  it('should increment and decrement pages respecting limits', () => {
+    component.totalPages = 2;
+    component.page = 1;
+    component.nextPage();
+    expect(component.page).toBe(2);
+    component.nextPage();
+    expect(component.page).toBe(2);
+    component.prevPage();
+    expect(component.page).toBe(1);
+    component.prevPage();
+    expect(component.page).toBe(1);
+  });
+
+  it('should zoom in and out respecting lower bound', () => {
+    const initial = component.zoom;
+    component.zoomIn();
+    expect(component.zoom).toBeCloseTo(initial + 0.1, 5);
+    for (let i = 0; i < 10; i++) {
+      component.zoomOut();
+    }
+    expect(component.zoom).toBeGreaterThan(0.39);
+  });
 });

--- a/src/app/footer/footer.component.spec.ts
+++ b/src/app/footer/footer.component.spec.ts
@@ -9,23 +9,31 @@ describe('FooterComponent', () => {
   let component: FooterComponent;
   let fixture: ComponentFixture<FooterComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [ FooterComponent ],
-      imports: [HttpClientTestingModule],
-      providers: [
-        { provide: Router, useValue: { navigate: () => {} } },
-        { provide: GithubService, useValue: { subscribe: () => ({unsubscribe(){}}) } }
-      ]
-    })
-    .compileComponents();
+beforeEach(async () => {
+  const navigateSpy = jasmine.createSpy('navigate');
+  await TestBed.configureTestingModule({
+    declarations: [ FooterComponent ],
+    imports: [HttpClientTestingModule],
+    providers: [
+      { provide: Router, useValue: { navigate: navigateSpy } },
+      { provide: GithubService, useValue: { subscribe: () => ({unsubscribe(){}}) } }
+    ]
+  })
+  .compileComponents();
 
-    fixture = TestBed.createComponent(FooterComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+  fixture = TestBed.createComponent(FooterComponent);
+  component = fixture.componentInstance as FooterComponent & { navigateSpy: jasmine.Spy };
+  (component as any).navigateSpy = navigateSpy;
+  fixture.detectChanges();
+});
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should navigate to experience on curriculum click', () => {
+    component.goToCurriculum();
+    const spy = (component as any).navigateSpy as jasmine.Spy;
+    expect(spy).toHaveBeenCalledWith(['/experience']);
   });
 });

--- a/src/app/navbar/navbar.component.spec.ts
+++ b/src/app/navbar/navbar.component.spec.ts
@@ -28,4 +28,10 @@ describe('NavbarComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should toggle menu state', () => {
+    expect(component.menuOpen).toBeFalse();
+    component.toggleMenu();
+    expect(component.menuOpen).toBeTrue();
+  });
 });

--- a/src/app/services/country.service.spec.ts
+++ b/src/app/services/country.service.spec.ts
@@ -1,19 +1,41 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 import { CountryService } from './country.service';
 
 describe('CountryService', () => {
   let service: CountryService;
+  let http: HttpTestingController;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule]
     });
     service = TestBed.inject(CountryService);
+    http = TestBed.inject(HttpTestingController);
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should fetch country info', done => {
+    service.subscribe(value => {
+      expect(value).toEqual({ ip: '1.1.1.1', country: 'US' });
+      done();
+    });
+    service.checkIP('1.1.1.1');
+    const req = http.expectOne('https://ipinfo.io/1.1.1.1?token=9351e0f5fa9e8c');
+    req.flush({ ip: '1.1.1.1', country: 'US' });
+  });
+
+  it('should return default on error', done => {
+    service.subscribe(value => {
+      expect(value).toEqual({ ip: '', country: '??' });
+      done();
+    });
+    service.checkIP('2.2.2.2');
+    const req = http.expectOne('https://ipinfo.io/2.2.2.2?token=9351e0f5fa9e8c');
+    req.flush('err', { status: 500, statusText: 'Server Error' });
   });
 });

--- a/src/app/services/github.service.spec.ts
+++ b/src/app/services/github.service.spec.ts
@@ -1,19 +1,38 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 import { GithubService } from './github.service';
 
 describe('GithubService', () => {
   let service: GithubService;
+  let http: HttpTestingController;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule]
     });
     service = TestBed.inject(GithubService);
+    http = TestBed.inject(HttpTestingController);
   });
 
-  it('should be created', () => {
-    expect(service).toBeTruthy();
+  it('should be created and load default user', done => {
+    service.subscribe(user => {
+      expect(user.login).toBe('FarDust');
+      done();
+    });
+    const req = http.expectOne('https://api.github.com/users/FarDust');
+    req.flush({ login: 'FarDust', avatar_url: '', url: '', html_url: '', name: '' });
+  });
+
+  it('should fetch given user', done => {
+    service.subscribe(user => {
+      if (user.login === 'foo') {
+        expect(user.name).toBe('Foo Bar');
+        done();
+      }
+    });
+    service.checkUser('foo');
+    const req = http.expectOne('https://api.github.com/users/foo');
+    req.flush({ login: 'foo', avatar_url: '', url: '', html_url: '', name: 'Foo Bar' });
   });
 });


### PR DESCRIPTION
## Summary
- enable `karma-coverage` and configure coverage reporter
- add unit tests for navbar, footer, viewer and console components
- extend country and GitHub service tests
- update lockfile after installing karma-coverage

## Testing
- `npm run test:dryrun`
- `npx ng test --code-coverage --browsers ChromeHeadlessNoSandbox --watch=false`


------
https://chatgpt.com/codex/tasks/task_e_684234843c148325a8213d813a3d646e