### PR TITLE
Implement i18n support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,8 @@
         "@fortawesome/free-brands-svg-icons": "^6.1.1",
         "@fortawesome/free-regular-svg-icons": "^6.1.1",
         "@fortawesome/free-solid-svg-icons": "^6.1.1",
+        "@ngx-translate/core": "^14.0.0",
+        "@ngx-translate/http-loader": "^7.0.0",
         "ng2-pdf-viewer": "^9.0.0",
         "pre-commit": "^1.2.2",
         "rxjs": "~7.5.5",
@@ -3338,6 +3340,33 @@
         "@angular/compiler-cli": "^15.0.0",
         "typescript": ">=4.8.2 <5.0",
         "webpack": "^5.54.0"
+      }
+    },
+    "node_modules/@ngx-translate/core": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@ngx-translate/core/-/core-14.0.0.tgz",
+      "integrity": "sha512-UevdwNCXMRCdJv//0kC8h2eSfmi02r29xeE8E9gJ1Al4D4jEJ7eiLPdjslTMc21oJNGguqqWeEVjf64SFtvw2w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/core": ">=13.0.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@ngx-translate/http-loader": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@ngx-translate/http-loader/-/http-loader-7.0.0.tgz",
+      "integrity": "sha512-j+NpXXlcGVdyUNyY/qsJrqqeAdJdizCd+GKh3usXExSqy1aE9866jlAIL+xrfDU4w+LiMoma5pgE4emvFebZmA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=13.0.0",
+        "@ngx-translate/core": ">=14.0.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -17698,6 +17727,22 @@
       "integrity": "sha512-jrpIOsEQxkWf5RnKn1izAixO+/hh6GkKmMl+hCv4rnn98XlKDmNRhG2KEIHJZF/3IEcAv9HVlIETRnLoVyJeeQ==",
       "dev": true,
       "requires": {}
+    },
+    "@ngx-translate/core": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@ngx-translate/core/-/core-14.0.0.tgz",
+      "integrity": "sha512-UevdwNCXMRCdJv//0kC8h2eSfmi02r29xeE8E9gJ1Al4D4jEJ7eiLPdjslTMc21oJNGguqqWeEVjf64SFtvw2w==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@ngx-translate/http-loader": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@ngx-translate/http-loader/-/http-loader-7.0.0.tgz",
+      "integrity": "sha512-j+NpXXlcGVdyUNyY/qsJrqqeAdJdizCd+GKh3usXExSqy1aE9866jlAIL+xrfDU4w+LiMoma5pgE4emvFebZmA==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "@fortawesome/free-regular-svg-icons": "^6.1.1",
     "@fortawesome/free-solid-svg-icons": "^6.1.1",
     "ng2-pdf-viewer": "^9.0.0",
+    "@ngx-translate/core": "^14.0.0",
+    "@ngx-translate/http-loader": "^7.0.0",
     "pre-commit": "^1.2.2",
     "rxjs": "~7.5.5",
     "three": "^0.152.2",

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AppComponent } from './app.component';
 
@@ -7,7 +8,8 @@ describe('AppComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule
+        RouterTestingModule,
+        TranslateModule.forRoot()
       ],
       declarations: [
         AppComponent

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-root',
@@ -7,4 +8,10 @@ import { Component } from '@angular/core';
 })
 export class AppComponent {
   title = 'landing-fardust';
+
+  constructor(private translate: TranslateService) {
+    translate.setDefaultLang('en');
+    const browserLang = translate.getBrowserLang();
+    translate.use(browserLang && browserLang.startsWith('es') ? 'es' : 'en');
+  }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -9,7 +9,9 @@ import { ServiceWorkerModule } from '@angular/service-worker';
 import { environment } from '../environments/environment';
 import { PageNotFoundComponent } from './page-not-found/page-not-found.component';
 import { FooterComponent } from './footer/footer.component';
-import { HttpClientModule } from '@angular/common/http';
+import { HttpClientModule, HttpClient } from '@angular/common/http';
+import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
+import { TranslateHttpLoader } from '@ngx-translate/http-loader';
 
 @NgModule({
   declarations: [
@@ -23,6 +25,13 @@ import { HttpClientModule } from '@angular/common/http';
     AppRoutingModule,
     HttpClientModule,
     FontAwesomeModule,
+    TranslateModule.forRoot({
+      loader: {
+        provide: TranslateLoader,
+        useFactory: HttpLoaderFactory,
+        deps: [HttpClient]
+      }
+    }),
     ServiceWorkerModule.register('ngsw-worker.js', {
       enabled: environment.production,
       // Register the ServiceWorker as soon as the app is stable
@@ -33,3 +42,7 @@ import { HttpClientModule } from '@angular/common/http';
   bootstrap: [AppComponent]
 })
 export class AppModule { }
+
+export function HttpLoaderFactory(http: HttpClient): TranslateHttpLoader {
+  return new TranslateHttpLoader(http, './assets/i18n/', '.json');
+}

--- a/src/app/experience/experience.module.ts
+++ b/src/app/experience/experience.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { PdfViewerModule } from 'ng2-pdf-viewer';
+import { TranslateModule } from '@ngx-translate/core';
 import { ExperienceComponent } from './experience.component';
 import { ExperienceRoutingModule } from './experience-routing.module';
 import { ViewerComponent } from './viewer/viewer.component';
@@ -15,7 +16,8 @@ import { ViewerComponent } from './viewer/viewer.component';
   imports: [
     CommonModule,
     ExperienceRoutingModule,
-    PdfViewerModule
+    PdfViewerModule,
+    TranslateModule
   ]
 })
 export class ExperienceModule { }

--- a/src/app/experience/viewer/viewer.component.html
+++ b/src/app/experience/viewer/viewer.component.html
@@ -1,25 +1,25 @@
 <div class="max-w-screen-lg mx-auto p-4">
   <div class="flex flex-col items-center space-y-4">
-    <h1 class="text-xl font-semibold">Curriculum Vitae</h1>
+    <h1 class="text-xl font-semibold">{{ 'cv_title' | translate }}</h1>
     <div class="space-x-2">
       <a [href]="pdfSrc" target="_blank" rel="noopener noreferrer"
         class="bg-[#343a40] hover:bg-[#2f5460] text-white px-4 py-2 rounded">
-        Abrir PDF
+        {{ 'open_pdf' | translate }}
       </a>
       <a [href]="pdfSrc" download
         class="bg-[#343a40] hover:bg-[#2f5460] text-white px-4 py-2 rounded">
-        Descargar
+        {{ 'download' | translate }}
       </a>
     </div>
     <div class="flex items-center space-x-2">
       <button (click)="prevPage()" [disabled]="page <= 1"
         class="bg-gray-200 px-2 py-1 rounded">
-        Anterior
+        {{ 'previous' | translate }}
       </button>
       <span>{{ page }} / {{ totalPages || '?' }}</span>
       <button (click)="nextPage()" [disabled]="totalPages && page >= totalPages"
         class="bg-gray-200 px-2 py-1 rounded">
-        Siguiente
+        {{ 'next' | translate }}
       </button>
       <button (click)="zoomOut()" [disabled]="zoom <= 0.5"
         class="bg-gray-200 px-2 py-1 rounded ml-2">

--- a/src/app/experience/viewer/viewer.component.spec.ts
+++ b/src/app/experience/viewer/viewer.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
 
 import { ViewerComponent } from './viewer.component';
 
@@ -10,6 +11,7 @@ describe('ViewerComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [ ViewerComponent ],
+      imports: [TranslateModule.forRoot()],
       schemas: [NO_ERRORS_SCHEMA]
     })
     .compileComponents();

--- a/src/app/home/home.module.ts
+++ b/src/app/home/home.module.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { ConsoleModule } from '../common/console/console.module';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { HttpClientModule } from '@angular/common/http';
+import { TranslateModule } from '@ngx-translate/core';
 import { HomeComponent } from './home.component';
 import { InfoComponent } from './info/info.component';
 import { HomeRoutingModule } from './home-routing.module';
@@ -19,7 +20,8 @@ import { HomeRoutingModule } from './home-routing.module';
     HomeRoutingModule,
     HttpClientModule,
     ConsoleModule,
-    FontAwesomeModule
+    FontAwesomeModule,
+    TranslateModule
   ]
 })
 export class HomeModule { }

--- a/src/app/home/home.module.ts
+++ b/src/app/home/home.module.ts
@@ -24,7 +24,7 @@ import { HomeRoutingModule } from './home-routing.module';
     HttpClientModule,
     ConsoleModule,
     FontAwesomeModule,
-    TranslateModule
+    TranslateModule,
     FormsModule
   ]
 })

--- a/src/app/home/info/info.component.html
+++ b/src/app/home/info/info.component.html
@@ -8,8 +8,8 @@
           <div class="lg:w-1/3 flex justify-center lg:justify-start mb-5 lg:mb-0">
             <div class="testimonial-item vertical-flex-center text-center lg:text-left">
               <img class="img-fluid rounded-circle mb-3 max-w-xs" src="{{ (githubService$ | async)?.avatar_url }}" alt="{{ (githubService$ | async)?.name ? (githubService$ | async)?.name + '\'s GitHub avatar' : 'GitHub avatar' }}">
-              <h5>I'm a Software Developer</h5>
-              <p class="font-weight-light mb-0">"Incorporating artificial intelligence systems into the products we use every day is my passion."</p>
+              <h5>{{ 'software_developer' | translate }}</h5>
+              <p class="font-weight-light mb-0">"{{ 'ai_passion' | translate }}"</p>
             </div>
           </div>
           <div class="lg:w-2/3 lg:pl-6">

--- a/src/app/home/info/info.component.spec.ts
+++ b/src/app/home/info/info.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
 import { CountryService } from 'src/app/services/country.service';
 import { GithubService } from 'src/app/services/github.service';
 
@@ -13,7 +14,7 @@ describe('HeaderComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [ InfoComponent ],
-      imports: [HttpClientTestingModule],
+      imports: [HttpClientTestingModule, TranslateModule.forRoot()],
       providers: [
         { provide: CountryService, useValue: { checkIP: () => {}, subscribe: () => ({unsubscribe(){}}) } },
         { provide: GithubService, useValue: { subscribe: () => ({unsubscribe(){}}) } }

--- a/src/app/page-not-found/page-not-found.component.html
+++ b/src/app/page-not-found/page-not-found.component.html
@@ -1,1 +1,1 @@
-<p>page-not-found works!</p>
+<p>{{ 'page_not_found' | translate }}</p>

--- a/src/app/page-not-found/page-not-found.component.spec.ts
+++ b/src/app/page-not-found/page-not-found.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
 
 import { PageNotFoundComponent } from './page-not-found.component';
 
@@ -8,7 +9,8 @@ describe('PageNotFoundComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ PageNotFoundComponent ]
+      declarations: [ PageNotFoundComponent ],
+      imports: [TranslateModule.forRoot()]
     })
     .compileComponents();
 

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1,0 +1,10 @@
+{
+  "cv_title": "Curriculum Vitae",
+  "open_pdf": "Open PDF",
+  "download": "Download",
+  "previous": "Previous",
+  "next": "Next",
+  "software_developer": "I'm a Software Developer",
+  "ai_passion": "Incorporating artificial intelligence systems into the products we use every day is my passion.",
+  "page_not_found": "Page not found!"
+}

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -1,0 +1,10 @@
+{
+  "cv_title": "Curr\u00EDculum Vitae",
+  "open_pdf": "Abrir PDF",
+  "download": "Descargar",
+  "previous": "Anterior",
+  "next": "Siguiente",
+  "software_developer": "Soy desarrollador de software",
+  "ai_passion": "Incorporar sistemas de inteligencia artificial en los productos que usamos a diario es mi pasi\u00F3n.",
+  "page_not_found": "\u00A1P\u00E1gina no encontrada!"
+}


### PR DESCRIPTION
## Summary
- add ngx-translate packages
- configure TranslateModule and loader
- set up language detection
- translate home info, viewer, and page not found components
- add English and Spanish translation files
- fix ngx-translate version and update specs to include TranslateModule

## Testing
- `npm run test:dryrun`

------
https://chatgpt.com/codex/tasks/task_e_6842376e9e708325aa30e8f9be8d2b4f