### PR TITLE
Add Prettier tooling

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,1 @@
+{ "singleQuote": true }

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "karma-jasmine-html-reporter": "^2.0.0",
         "postcss": "^8.4.21",
         "postcss-loader": "^7.0.0",
+        "prettier": "^3.5.3",
         "tailwindcss": "^3.2.7",
         "ts-node": "~10.8.0",
         "typescript": "~4.9.5"
@@ -12082,6 +12083,22 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pretty-bytes": {
       "version": "5.6.0",
       "dev": true,
@@ -23900,6 +23917,12 @@
     },
     "prelude-ls": {
       "version": "1.2.1",
+      "dev": true
+    },
+    "prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true
     },
     "pretty-bytes": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "lint": "ng lint",
     "fix": "ng lint --fix",
     "e2e": "ng e2e",
-    "deploy": "firebase deploy --only hosting:fardust"
+    "deploy": "firebase deploy --only hosting:fardust",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "private": true,
   "dependencies": {
@@ -62,12 +64,14 @@
     "karma-jasmine-html-reporter": "^2.0.0",
     "postcss": "^8.4.21",
     "postcss-loader": "^7.0.0",
+    "prettier": "^3.5.3",
     "tailwindcss": "^3.2.7",
     "ts-node": "~10.8.0",
     "typescript": "~4.9.5"
   },
   "pre-commit": [
     "fix",
-    "test:dryrun"
+    "test:dryrun",
+    "format:check"
   ]
 }


### PR DESCRIPTION
## Summary
- add `.prettierrc` with singleQuote preference
- install `prettier`
- provide `format` and `format:check` npm scripts
- run `format:check` in pre-commit hook

## Testing
- `npm run format:check`
- `npm run test:dryrun`

------
https://chatgpt.com/codex/tasks/task_e_68423db40bb48325bb244bb24863a6d4