### PR TITLE
Fix missing comma in HomeModule imports

### DIFF
--- a/src/app/home/home.module.ts
+++ b/src/app/home/home.module.ts
@@ -24,7 +24,7 @@ import { HomeRoutingModule } from './home-routing.module';
     HttpClientModule,
     ConsoleModule,
     FontAwesomeModule,
-    TranslateModule
+    TranslateModule,
     FormsModule
   ]
 })


### PR DESCRIPTION
## Summary
- fix parsing error in `HomeModule`

## Testing
- `npm run lint`
- `npm run test:dryrun`

------
https://chatgpt.com/codex/tasks/task_e_684241da03f88325bdeb9702493495f7