### PR TITLE
fix(review): address PR 359 follow-up comments

### DIFF
--- a/src/app/common/console/console.module.ts
+++ b/src/app/common/console/console.module.ts
@@ -2,16 +2,12 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ConsoleComponent } from './console.component';
 import { CountryService } from '../../services/country.service';
-import {
-  provideHttpClient,
-  withInterceptorsFromDi,
-} from '@angular/common/http';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 
 @NgModule({
   declarations: [ConsoleComponent],
   exports: [ConsoleComponent],
   imports: [CommonModule, FontAwesomeModule],
-  providers: [CountryService, provideHttpClient(withInterceptorsFromDi())],
+  providers: [CountryService],
 })
 export class ConsoleModule {}

--- a/src/app/home/home.module.ts
+++ b/src/app/home/home.module.ts
@@ -2,10 +2,6 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ConsoleModule } from '../common/console/console.module';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
-import {
-  provideHttpClient,
-  withInterceptorsFromDi,
-} from '@angular/common/http';
 import { TranslateModule } from '@ngx-translate/core';
 import { FormsModule } from '@angular/forms';
 import { PersonalInfoComponent } from './personal-info/personal-info.component';
@@ -23,6 +19,5 @@ import { HomeRoutingModule } from './home-routing.module';
     TranslateModule,
     FormsModule,
   ],
-  providers: [provideHttpClient(withInterceptorsFromDi())],
 })
 export class HomeModule {}

--- a/src/app/home/info/info.component.html
+++ b/src/app/home/info/info.component.html
@@ -94,7 +94,7 @@
                     class="block bg-[#343a40] hover:bg-[#2f5460] text-white px-4 py-2 rounded transition-transform duration-300 hover:-translate-y-1 hover:scale-105"
                   >
                     🔨 Legacy Member of <i class="fab fa-osi"></i> Open Source
-                    UC comunity</a
+                    UC community</a
                   >
                 </li>
                 <li>


### PR DESCRIPTION
## Summary
- remove duplicate `provideHttpClient(withInterceptorsFromDi())` providers from `HomeModule` and `ConsoleModule`
- fix the `Open Source UC community` copy typo on the landing page
- follow up on the review comments left on merged PR #359

## Verification
- npm run lint
- npm run build
- CHROME_BIN=$(command -v google-chrome-stable || command -v google-chrome) npm run test:dryrun

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected spelling in the "UC Community" shortcut link text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->