### PR TITLE
fix(landing): harden private notes and WebGL fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,19 @@ npm run deploy      # Deploy to Firebase
 ### Personal section
 
 Set `personalInfoUrl` in `src/environments/environment.ts` to the Cloud Run
-endpoint that returns your private bio. The personal section shows a short
-public summary by default and automatically fetches additional details when a
-valid token is available. The token will be sent as a `token` query parameter
-(e.g. `?token=YOUR_TOKEN`) and persisted in a `personal_token` cookie so you
-don't have to re-enter it.
+endpoint that returns your private bio. If `personalInfoUrl` is left blank, the
+private notes feature stays disabled and no request is made from the landing
+page.
+
+The personal section shows a short public summary by default and can fetch
+additional details when a valid token is available. The frontend sends the
+token in an `Authorization: Bearer <token>` header and persists it in a
+`personal_token` cookie so you don't have to re-enter it.
+
+> **Security note:** Treat this token as sensitive. Prefer HTTPS, keep tokens
+> short-lived, and use cookie attributes such as `Secure` and `SameSite=Strict`
+> when persisting it client-side.
 
 ## 📚 Learn More
 
 Check the source code for examples of Angular modules, components and RxJS usage. Feel free to explore the project and modify it to suit your own portfolio! 💻
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,6 @@
         "karma": "~6.4.0",
         "karma-chrome-launcher": "~3.1.0",
         "karma-coverage": "~2.2.0",
-        "karma-coverage-istanbul-reporter": "~3.0.2",
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "^2.0.0",
         "postcss": "^8.4.21",
@@ -12123,109 +12122,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/istanbul-lib-source-maps": {
-      "version": "3.0.6",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^2.0.5",
-        "make-dir": "^2.1.0",
-        "rimraf": "^2.6.3",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps/node_modules/glob": {
-      "version": "7.2.3",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps/node_modules/istanbul-lib-coverage": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps/node_modules/make-dir": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pify": "^4.0.1",
-        "semver": "^5.6.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps/node_modules/minimatch": {
-      "version": "3.1.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps/node_modules/pify": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps/node_modules/rimraf": {
-      "version": "2.7.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/istanbul-reports": {
       "version": "3.1.4",
       "dev": true,
@@ -12470,41 +12366,6 @@
       },
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/karma-coverage-istanbul-reporter": {
-      "version": "3.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "istanbul-lib-coverage": "^3.0.0",
-        "istanbul-lib-report": "^3.0.0",
-        "istanbul-lib-source-maps": "^3.0.6",
-        "istanbul-reports": "^3.0.2",
-        "minimatch": "^3.0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mattlewis92"
-      }
-    },
-    "node_modules/karma-coverage-istanbul-reporter/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/karma-coverage-istanbul-reporter/node_modules/minimatch": {
-      "version": "3.1.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/karma-coverage/node_modules/brace-expansion": {
@@ -25416,75 +25277,6 @@
         "supports-color": "^7.1.0"
       }
     },
-    "istanbul-lib-source-maps": {
-      "version": "3.0.6",
-      "dev": true,
-      "requires": {
-        "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^2.0.5",
-        "make-dir": "^2.1.0",
-        "rimraf": "^2.6.3",
-        "source-map": "^0.6.1"
-      },
-      "dependencies": {
-        "brace-expansion": {
-          "version": "1.1.11",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "glob": {
-          "version": "7.2.3",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.1.1",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "istanbul-lib-coverage": {
-          "version": "2.0.5",
-          "dev": true
-        },
-        "make-dir": {
-          "version": "2.1.0",
-          "dev": true,
-          "requires": {
-            "pify": "^4.0.1",
-            "semver": "^5.6.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.1.2",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "pify": {
-          "version": "4.0.1",
-          "dev": true
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "semver": {
-          "version": "5.7.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-          "dev": true
-        }
-      }
-    },
     "istanbul-reports": {
       "version": "3.1.4",
       "dev": true,
@@ -25743,34 +25535,6 @@
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
           "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        }
-      }
-    },
-    "karma-coverage-istanbul-reporter": {
-      "version": "3.0.3",
-      "dev": true,
-      "requires": {
-        "istanbul-lib-coverage": "^3.0.0",
-        "istanbul-lib-report": "^3.0.0",
-        "istanbul-lib-source-maps": "^3.0.6",
-        "istanbul-reports": "^3.0.2",
-        "minimatch": "^3.0.4"
-      },
-      "dependencies": {
-        "brace-expansion": {
-          "version": "1.1.11",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "minimatch": {
-          "version": "3.1.2",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.1.0",
     "karma-coverage": "~2.2.0",
-    "karma-coverage-istanbul-reporter": "~3.0.2",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "^2.0.0",
     "postcss": "^8.4.21",

--- a/src/app/ball/ball.component.html
+++ b/src/app/ball/ball.component.html
@@ -1,3 +1,11 @@
 <div class="ball-container">
-  <canvas #canvas></canvas>
+  @if (renderError) {
+    <div class="ball-fallback">
+      <h1>{{ 'webgl_ball_demo' | translate }}</h1>
+      <p>{{ 'webgl_ball_unavailable' | translate }}</p>
+      <a routerLink="/">{{ 'back_home' | translate }}</a>
+    </div>
+  } @else {
+    <canvas #canvas></canvas>
+  }
 </div>

--- a/src/app/ball/ball.component.sass
+++ b/src/app/ball/ball.component.sass
@@ -24,3 +24,10 @@
 
   a
     color: #67e8f9
+    text-decoration: underline
+    transition: color 0.2s ease
+
+    &:hover,
+    &:focus,
+    &:focus-visible
+      color: #a5f3fc

--- a/src/app/ball/ball.component.sass
+++ b/src/app/ball/ball.component.sass
@@ -2,7 +2,25 @@
   width: 100%
   height: 100vh
   overflow: hidden
+  display: flex
+  align-items: center
+  justify-content: center
   canvas
     width: 100%
     height: 100%
     display: block
+
+.ball-fallback
+  max-width: 32rem
+  padding: 2rem
+  text-align: center
+
+  h1
+    font-size: 2rem
+    margin-bottom: 1rem
+
+  p
+    margin-bottom: 1rem
+
+  a
+    color: #67e8f9

--- a/src/app/ball/ball.component.spec.ts
+++ b/src/app/ball/ball.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateModule } from '@ngx-translate/core';
+import { provideRouter, RouterModule } from '@angular/router';
 import { BallComponent } from './ball.component';
 
 describe('BallComponent', () => {
@@ -10,7 +10,8 @@ describe('BallComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [BallComponent],
-      imports: [RouterTestingModule, TranslateModule.forRoot()],
+      imports: [RouterModule, TranslateModule.forRoot()],
+      providers: [provideRouter([])],
     }).compileComponents();
   });
 

--- a/src/app/ball/ball.component.spec.ts
+++ b/src/app/ball/ball.component.spec.ts
@@ -1,0 +1,42 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { BallComponent } from './ball.component';
+
+describe('BallComponent', () => {
+  let component: BallComponent;
+  let fixture: ComponentFixture<BallComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [BallComponent],
+      imports: [RouterTestingModule, TranslateModule.forRoot()],
+    }).compileComponents();
+  });
+
+  it('should create when the scene initializes successfully', () => {
+    fixture = TestBed.createComponent(BallComponent);
+    component = fixture.componentInstance;
+    spyOn<any>(component, 'initScene').and.stub();
+    spyOn<any>(component, 'animate').and.stub();
+
+    fixture.detectChanges();
+
+    expect(component).toBeTruthy();
+    expect(component.renderError).toBeFalse();
+  });
+
+  it('should show the fallback UI when WebGL initialization fails', () => {
+    fixture = TestBed.createComponent(BallComponent);
+    component = fixture.componentInstance;
+    spyOn<any>(component, 'initScene').and.throwError('WebGL unavailable');
+    spyOn<any>(component, 'animate').and.stub();
+
+    fixture.detectChanges();
+
+    expect(component.renderError).toBeTrue();
+    expect(
+      fixture.nativeElement.querySelector('.ball-fallback'),
+    ).not.toBeNull();
+  });
+});

--- a/src/app/ball/ball.component.ts
+++ b/src/app/ball/ball.component.ts
@@ -1,5 +1,6 @@
 import {
   AfterViewInit,
+  ChangeDetectorRef,
   Component,
   ElementRef,
   OnDestroy,
@@ -17,35 +18,42 @@ export class BallComponent implements AfterViewInit, OnDestroy {
   @ViewChild('canvas', { static: true })
   canvasRef!: ElementRef<HTMLCanvasElement>;
 
-  private renderer!: THREE.WebGLRenderer;
-  private scene!: THREE.Scene;
-  private camera!: THREE.PerspectiveCamera;
-  private sphere!: THREE.Mesh;
+  renderError = false;
+
+  private renderer?: THREE.WebGLRenderer;
+  private scene?: THREE.Scene;
+  private camera?: THREE.PerspectiveCamera;
+  private sphere?: THREE.Mesh;
   private animationId?: number;
   private clock = new THREE.Clock();
 
+  constructor(private cdr: ChangeDetectorRef) {}
+
   ngAfterViewInit(): void {
-    this.initScene();
-    this.animate();
+    try {
+      this.initScene();
+      this.animate();
+    } catch {
+      this.renderError = true;
+      this.cdr.detectChanges();
+    }
   }
 
   ngOnDestroy(): void {
     if (this.animationId) {
       cancelAnimationFrame(this.animationId);
     }
-    if (this.sphere) {
-      if (this.sphere.geometry) {
-        this.sphere.geometry.dispose();
-      }
-      if (this.sphere.material) {
-        if (Array.isArray(this.sphere.material)) {
-          this.sphere.material.forEach((material) => material.dispose());
-        } else {
-          this.sphere.material.dispose();
-        }
-      }
-      this.sphere = null!;
+    if (this.sphere?.geometry) {
+      this.sphere.geometry.dispose();
     }
+    if (this.sphere?.material) {
+      if (Array.isArray(this.sphere.material)) {
+        this.sphere.material.forEach((material) => material.dispose());
+      } else {
+        this.sphere.material.dispose();
+      }
+    }
+    this.sphere = undefined;
     if (this.renderer) {
       this.renderer.dispose();
     }
@@ -86,6 +94,10 @@ export class BallComponent implements AfterViewInit, OnDestroy {
   }
 
   private animate = (): void => {
+    if (!this.renderer || !this.camera || !this.sphere) {
+      return;
+    }
+
     this.animationId = requestAnimationFrame(this.animate);
 
     const t = this.clock.getElapsedTime();
@@ -106,6 +118,10 @@ export class BallComponent implements AfterViewInit, OnDestroy {
   };
 
   private onWindowResize = (): void => {
+    if (!this.camera || !this.renderer) {
+      return;
+    }
+
     const canvas = this.canvasRef.nativeElement;
     const width = canvas.clientWidth;
     const height = canvas.clientHeight;

--- a/src/app/ball/ball.component.ts
+++ b/src/app/ball/ball.component.ts
@@ -94,7 +94,7 @@ export class BallComponent implements AfterViewInit, OnDestroy {
   }
 
   private animate = (): void => {
-    if (!this.renderer || !this.camera || !this.sphere) {
+    if (!this.renderer || !this.scene || !this.camera || !this.sphere) {
       return;
     }
 

--- a/src/app/ball/ball.component.ts
+++ b/src/app/ball/ball.component.ts
@@ -33,7 +33,11 @@ export class BallComponent implements AfterViewInit, OnDestroy {
     try {
       this.initScene();
       this.animate();
-    } catch {
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (!/webgl/i.test(message)) {
+        console.error('Failed to initialize BallComponent 3D scene:', error);
+      }
       this.renderError = true;
       this.cdr.detectChanges();
     }

--- a/src/app/ball/ball.module.ts
+++ b/src/app/ball/ball.module.ts
@@ -1,10 +1,11 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { TranslateModule } from '@ngx-translate/core';
 import { BallRoutingModule } from './ball-routing.module';
 import { BallComponent } from './ball.component';
 
 @NgModule({
   declarations: [BallComponent],
-  imports: [CommonModule, BallRoutingModule]
+  imports: [CommonModule, BallRoutingModule, TranslateModule],
 })
-export class BallModule { }
+export class BallModule {}

--- a/src/app/common/console/console.component.html
+++ b/src/app/common/console/console.component.html
@@ -20,7 +20,7 @@
     @if ((countryservice$ | async)?.country === 'CL') {
       <span class="console-command">Major</span> of {{ major }}
     } @else {
-      <span class="console-command">Degree</span> in {{ major }}ing
+      <span class="console-command">Degree</span> in {{ major }}
     }
     <br />
     <span class="console-input">> </span>

--- a/src/app/common/console/console.component.spec.ts
+++ b/src/app/common/console/console.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { of } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { CountryService } from '../../services/country.service';
 
 import { ConsoleComponent } from './console.component';
@@ -10,13 +10,18 @@ describe('ConsoleComponent', () => {
   let fixture: ComponentFixture<ConsoleComponent>;
 
   let checkIPSpy: jasmine.Spy;
-  let countryServiceStub: CountryService;
+  let countryServiceStub: {
+    checkIP: jasmine.Spy;
+    subscribe: typeof Observable.prototype.subscribe;
+  };
 
   beforeEach(async () => {
     checkIPSpy = jasmine.createSpy('checkIP');
-    countryServiceStub = Object.assign(of({ ip: '', country: 'US' }), {
+    const countryResult$ = of({ ip: '', country: 'US' });
+    countryServiceStub = {
       checkIP: checkIPSpy,
-    }) as unknown as CountryService;
+      subscribe: countryResult$.subscribe.bind(countryResult$),
+    };
 
     await TestBed.configureTestingModule({
       declarations: [ConsoleComponent],

--- a/src/app/common/console/console.component.spec.ts
+++ b/src/app/common/console/console.component.spec.ts
@@ -1,22 +1,23 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { of } from 'rxjs';
 import { CountryService } from '../../services/country.service';
 
 import { ConsoleComponent } from './console.component';
-import {
-  provideHttpClient,
-  withInterceptorsFromDi,
-} from '@angular/common/http';
 
 describe('ConsoleComponent', () => {
   let component: ConsoleComponent;
   let fixture: ComponentFixture<ConsoleComponent>;
 
   let checkIPSpy: jasmine.Spy;
+  let countryServiceStub: CountryService;
 
   beforeEach(async () => {
     checkIPSpy = jasmine.createSpy('checkIP');
+    countryServiceStub = Object.assign(of({ ip: '', country: 'US' }), {
+      checkIP: checkIPSpy,
+    }) as unknown as CountryService;
+
     await TestBed.configureTestingModule({
       declarations: [ConsoleComponent],
       schemas: [NO_ERRORS_SCHEMA],
@@ -24,18 +25,15 @@ describe('ConsoleComponent', () => {
       providers: [
         {
           provide: CountryService,
-          useValue: {
-            checkIP: checkIPSpy,
-            subscribe: () => ({ unsubscribe() {} }),
-          },
+          useValue: countryServiceStub,
         },
-        provideHttpClient(withInterceptorsFromDi()),
-        provideHttpClientTesting(),
       ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ConsoleComponent);
     component = fixture.componentInstance;
+    component.major = 'Software Engineering';
+    component.minor = 'Computer Science';
     fixture.detectChanges();
   });
 
@@ -45,5 +43,12 @@ describe('ConsoleComponent', () => {
 
   it('should request IP on init', () => {
     expect(checkIPSpy).toHaveBeenCalledWith('');
+  });
+
+  it('should render the degree line without duplicating the major suffix', () => {
+    const text = fixture.nativeElement.textContent.replace(/\s+/g, ' ');
+
+    expect(text).toContain('Degree in Software Engineering');
+    expect(text).not.toContain('Software Engineeringing');
   });
 });

--- a/src/app/home/info/info.component.html
+++ b/src/app/home/info/info.component.html
@@ -123,8 +123,8 @@
                   <a
                     routerLink="/ball"
                     class="block bg-[#343a40] hover:bg-[#2f5460] text-white px-4 py-2 rounded"
-                    aria-label="WebGL Ball Demo"
-                    >🟢 WebGL Ball Demo</a
+                    [attr.aria-label]="'webgl_ball_demo' | translate"
+                    >🟢 {{ 'webgl_ball_demo' | translate }}</a
                   >
                 </li>
               </ul>

--- a/src/app/home/personal-info/personal-info.component.html
+++ b/src/app/home/personal-info/personal-info.component.html
@@ -17,6 +17,9 @@
           [(ngModel)]="token"
           class="w-full rounded border border-white/20 bg-black/20 px-3 py-2 text-white placeholder:text-white/50"
           [placeholder]="'personal_info_token_placeholder' | translate"
+          autocomplete="off"
+          spellcheck="false"
+          autocapitalize="none"
         />
         <div class="flex flex-wrap gap-2">
           <button

--- a/src/app/home/personal-info/personal-info.component.html
+++ b/src/app/home/personal-info/personal-info.component.html
@@ -1,7 +1,46 @@
 <div class="personal-info my-4">
-  <p class="mb-4 whitespace-pre-line">{{ publicBio }}</p>
-  @if (error) {
-    <p class="text-red-600">{{ error }}</p>
+  <p class="mb-4 whitespace-pre-line">
+    {{ 'personal_info_public_bio' | translate }}
+  </p>
+  @if (personalInfoEnabled) {
+    <details class="rounded border border-white/10 bg-black/10 p-4 text-left">
+      <summary class="cursor-pointer font-semibold">
+        {{ 'personal_info_toggle' | translate }}
+      </summary>
+      <div class="mt-3 space-y-3">
+        <label class="block text-sm font-medium" for="personal-token">
+          {{ 'personal_info_token_label' | translate }}
+        </label>
+        <input
+          id="personal-token"
+          type="password"
+          [(ngModel)]="token"
+          class="w-full rounded border border-white/20 bg-black/20 px-3 py-2 text-white placeholder:text-white/50"
+          [placeholder]="'personal_info_token_placeholder' | translate"
+        />
+        <div class="flex flex-wrap gap-2">
+          <button
+            type="button"
+            class="rounded bg-cyan-700 px-3 py-2 text-sm text-white hover:bg-cyan-600"
+            (click)="submitToken()"
+          >
+            {{ 'personal_info_load' | translate }}
+          </button>
+          @if (token) {
+            <button
+              type="button"
+              class="rounded border border-white/20 px-3 py-2 text-sm text-white hover:bg-white/10"
+              (click)="clearToken()"
+            >
+              {{ 'personal_info_clear' | translate }}
+            </button>
+          }
+        </div>
+      </div>
+    </details>
+  }
+  @if (errorKey) {
+    <p class="mt-3 text-red-300">{{ errorKey | translate }}</p>
   }
   @if (personal$ | async; as personal) {
     <div class="mt-2 whitespace-pre-line">{{ personal.privateBio }}</div>

--- a/src/app/home/personal-info/personal-info.component.spec.ts
+++ b/src/app/home/personal-info/personal-info.component.spec.ts
@@ -11,8 +11,8 @@ describe('PersonalInfoComponent', () => {
   let personalInfoService: jasmine.SpyObj<PersonalInfoService>;
 
   const clearTokenCookie = () => {
-    document.cookie =
-      'personal_token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; SameSite=Strict';
+    const secure = window.location.protocol === 'https:' ? '; Secure' : '';
+    document.cookie = `personal_token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; SameSite=Strict${secure}`;
   };
 
   beforeEach(async () => {

--- a/src/app/home/personal-info/personal-info.component.spec.ts
+++ b/src/app/home/personal-info/personal-info.component.spec.ts
@@ -1,56 +1,116 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { of, throwError } from 'rxjs';
 import { PersonalInfoComponent } from './personal-info.component';
-import {
-  provideHttpClient,
-  withInterceptorsFromDi,
-} from '@angular/common/http';
+import { PersonalInfoService } from '../../services/personal-info.service';
 
 describe('PersonalInfoComponent', () => {
   let component: PersonalInfoComponent;
   let fixture: ComponentFixture<PersonalInfoComponent>;
+  let personalInfoService: jasmine.SpyObj<PersonalInfoService>;
+
+  const clearTokenCookie = () => {
+    document.cookie =
+      'personal_token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; SameSite=Strict';
+  };
 
   beforeEach(async () => {
+    personalInfoService = jasmine.createSpyObj<PersonalInfoService>(
+      'PersonalInfoService',
+      ['getPersonalInfo', 'isConfigured'],
+    );
+    personalInfoService.isConfigured.and.returnValue(true);
+    personalInfoService.getPersonalInfo.and.returnValue(
+      of({ privateBio: 'secret' }),
+    );
+
     await TestBed.configureTestingModule({
       declarations: [PersonalInfoComponent],
-      imports: [FormsModule],
+      imports: [FormsModule, TranslateModule.forRoot()],
       providers: [
-        provideHttpClient(withInterceptorsFromDi()),
-        provideHttpClientTesting(),
+        { provide: PersonalInfoService, useValue: personalInfoService },
       ],
     }).compileComponents();
   });
 
   beforeEach(() => {
-    document.cookie =
-      'personal_token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+    clearTokenCookie();
+  });
+
+  afterEach(() => {
+    clearTokenCookie();
+  });
+
+  const createComponent = () => {
     fixture = TestBed.createComponent(PersonalInfoComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
-  });
+  };
 
   it('should create', () => {
+    createComponent();
+
     expect(component).toBeTruthy();
   });
 
-  it('should have public bio defined', () => {
-    expect(component.publicBio.length).toBeGreaterThan(0);
-  });
+  it('should load the token from the cookie when the feature is configured', () => {
+    clearTokenCookie();
+    document.cookie = 'personal_token=cookieTok; path=/';
 
-  it('should load token from cookie and call load', () => {
-    document.cookie = 'personal_token=cookieTok';
-    fixture = TestBed.createComponent(PersonalInfoComponent);
-    component = fixture.componentInstance;
-    spyOn(component, 'load');
-    fixture.detectChanges();
+    createComponent();
+
     expect(component.token).toBe('cookieTok');
-    expect(component.load).toHaveBeenCalled();
+    expect(personalInfoService.getPersonalInfo).toHaveBeenCalledWith(
+      'cookieTok',
+    );
   });
 
-  it('should store token in cookie when changed', () => {
+  it('should not load the token when the feature is disabled', () => {
+    personalInfoService.isConfigured.and.returnValue(false);
+    clearTokenCookie();
+    document.cookie = 'personal_token=cookieTok; path=/';
+
+    createComponent();
+
+    expect(component.token).toBe('');
+    expect(personalInfoService.getPersonalInfo).not.toHaveBeenCalled();
+  });
+
+  it('should store the token in a cookie and request private info on submit', () => {
+    createComponent();
     component.token = 'saveTok';
-    component.tokenChanged();
+
+    component.submitToken();
+
     expect(document.cookie).toContain('personal_token=saveTok');
+    expect(personalInfoService.getPersonalInfo).toHaveBeenCalledWith('saveTok');
+  });
+
+  it('should clear the stored token and loaded state', () => {
+    createComponent();
+    component.token = 'saveTok';
+    component.personal$ = of({ privateBio: 'secret' });
+    component.errorKey = 'personal_info_load_failed';
+
+    component.clearToken();
+
+    expect(component.token).toBe('');
+    expect(component.errorKey).toBe('');
+    expect(component.personal$).toBeUndefined();
+    expect(document.cookie).not.toContain('personal_token=');
+  });
+
+  it('should expose a translated error key when the request fails', () => {
+    personalInfoService.getPersonalInfo.and.returnValue(
+      throwError(() => new Error('boom')),
+    );
+    createComponent();
+
+    component.token = 'broken';
+    component.load();
+    component.personal$?.subscribe();
+
+    expect(component.errorKey).toBe('personal_info_load_failed');
   });
 });

--- a/src/app/home/personal-info/personal-info.component.ts
+++ b/src/app/home/personal-info/personal-info.component.ts
@@ -54,7 +54,8 @@ export class PersonalInfoComponent implements OnInit {
     this.token = '';
     this.errorKey = '';
     this.personal$ = undefined;
-    document.cookie = `${TOKEN_COOKIE}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; SameSite=Strict`;
+    const secure = window.location.protocol === 'https:' ? '; Secure' : '';
+    document.cookie = `${TOKEN_COOKIE}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; SameSite=Strict${secure}`;
   }
 
   load(): void {

--- a/src/app/home/personal-info/personal-info.component.ts
+++ b/src/app/home/personal-info/personal-info.component.ts
@@ -3,7 +3,7 @@ import {
   PersonalInfoService,
   PrivateInfo,
 } from '../../services/personal-info.service';
-import { Observable, of } from 'rxjs';
+import { EMPTY, Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 const TOKEN_COOKIE = 'personal_token';
@@ -17,40 +17,65 @@ const TOKEN_COOKIE = 'personal_token';
 export class PersonalInfoComponent implements OnInit {
   token = '';
   personal$?: Observable<PrivateInfo>;
-  error = '';
-  readonly publicBio =
-    'Soy una persona curiosa y enérgica. Reparto mi tiempo entre trabajar, entrenar y disfrutar de los videojuegos. ' +
-    'Viajar solo me permite observar cómo funcionan las cosas en distintos lugares, siempre acompañado de mi gato y buenos amigos.';
+  errorKey = '';
+  readonly personalInfoEnabled: boolean;
 
-  constructor(private personalService: PersonalInfoService) {}
+  constructor(private personalService: PersonalInfoService) {
+    this.personalInfoEnabled = this.personalService.isConfigured();
+  }
 
   ngOnInit(): void {
-    const match = document.cookie.match(
-      new RegExp('(?:^|; )' + TOKEN_COOKIE + '=([^;]*)'),
-    );
-    this.token = match ? decodeURIComponent(match[1]) : '';
+    if (!this.personalInfoEnabled) {
+      return;
+    }
+
+    this.token = this.readTokenFromCookie();
     if (this.token) {
       this.load();
     }
   }
 
-  tokenChanged(): void {
-    if (!this.token) {
-      document.cookie = `${TOKEN_COOKIE}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
-      this.personal$ = undefined;
+  submitToken(): void {
+    if (!this.personalInfoEnabled) {
       return;
     }
+
+    this.token = this.token.trim();
+    if (!this.token) {
+      this.clearToken();
+      return;
+    }
+
+    this.persistToken(this.token);
     this.load();
   }
 
+  clearToken(): void {
+    this.token = '';
+    this.errorKey = '';
+    this.personal$ = undefined;
+    document.cookie = `${TOKEN_COOKIE}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; SameSite=Strict`;
+  }
+
   load(): void {
-    this.error = '';
-    document.cookie = `${TOKEN_COOKIE}=${encodeURIComponent(this.token)}; path=/`;
+    this.errorKey = '';
     this.personal$ = this.personalService.getPersonalInfo(this.token).pipe(
       catchError(() => {
-        this.error = 'Could not load personal info';
-        return of({ privateBio: '' });
+        this.errorKey = 'personal_info_load_failed';
+        return EMPTY;
       }),
     );
+  }
+
+  private readTokenFromCookie(): string {
+    const match = document.cookie.match(
+      new RegExp('(?:^|; )' + TOKEN_COOKIE + '=([^;]*)'),
+    );
+    return match ? decodeURIComponent(match[1]) : '';
+  }
+
+  private persistToken(token: string): void {
+    const secure = window.location.protocol === 'https:' ? '; Secure' : '';
+    document.cookie = `${TOKEN_COOKIE}=${encodeURIComponent(token)}; path=/; SameSite=Strict${secure}`;
   }
 }

--- a/src/app/services/personal-info.service.spec.ts
+++ b/src/app/services/personal-info.service.spec.ts
@@ -13,8 +13,10 @@ import {
 describe('PersonalInfoService', () => {
   let service: PersonalInfoService;
   let httpMock: HttpTestingController;
+  let originalPersonalInfoUrl: string;
 
   beforeEach(() => {
+    originalPersonalInfoUrl = environment.personalInfoUrl;
     TestBed.configureTestingModule({
       imports: [],
       providers: [
@@ -27,8 +29,17 @@ describe('PersonalInfoService', () => {
     (environment as any).personalInfoUrl = '/info';
   });
 
+  afterEach(() => {
+    (environment as any).personalInfoUrl = originalPersonalInfoUrl;
+    httpMock.verify();
+  });
+
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should report when the feature is configured', () => {
+    expect(service.isConfigured()).toBeTrue();
   });
 
   it('should fetch private info', () => {
@@ -36,10 +47,31 @@ describe('PersonalInfoService', () => {
     service.getPersonalInfo('tok').subscribe((data) => {
       expect(data).toEqual(mock);
     });
-    const req = httpMock.expectOne('/info?token=tok');
-    expect(req.request.params.get('token')).toBe('tok');
-    expect(req.request.headers.has('Authorization')).toBeFalse();
+    const req = httpMock.expectOne(
+      new URL('/info', window.location.origin).toString(),
+    );
+    expect(req.request.params.has('token')).toBeFalse();
+    expect(req.request.headers.get('Authorization')).toBe('Bearer tok');
     req.flush(mock);
-    httpMock.verify();
+  });
+
+  it('should reject requests when the URL is not configured', () => {
+    (environment as any).personalInfoUrl = '';
+
+    service.getPersonalInfo('tok').subscribe({
+      next: () =>
+        fail('Expected getPersonalInfo to error when no URL is configured'),
+      error: (error: Error) => {
+        expect(error.message).toContain('not configured');
+      },
+    });
+
+    httpMock.expectNone(() => true);
+  });
+
+  it('should report when the feature is disabled', () => {
+    (environment as any).personalInfoUrl = '';
+
+    expect(service.isConfigured()).toBeFalse();
   });
 });

--- a/src/app/services/personal-info.service.ts
+++ b/src/app/services/personal-info.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
 import { environment } from '../../environments/environment';
 
 export interface PrivateInfo {
@@ -8,13 +8,38 @@ export interface PrivateInfo {
 }
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class PersonalInfoService {
   constructor(private http: HttpClient) {}
 
+  isConfigured(): boolean {
+    return this.resolveUrl() !== null;
+  }
+
   getPersonalInfo(token: string): Observable<PrivateInfo> {
-    const params = new HttpParams().set('token', token);
-    return this.http.get<PrivateInfo>(environment.personalInfoUrl, { params });
+    const resolvedUrl = this.resolveUrl();
+    if (!resolvedUrl) {
+      return throwError(() => new Error('Personal info URL is not configured'));
+    }
+
+    return this.http.get<PrivateInfo>(resolvedUrl, {
+      headers: new HttpHeaders({
+        Authorization: `Bearer ${token}`,
+      }),
+    });
+  }
+
+  private resolveUrl(): string | null {
+    const rawUrl = environment.personalInfoUrl?.trim();
+    if (!rawUrl) {
+      return null;
+    }
+
+    try {
+      return new URL(rawUrl, window.location.origin).toString();
+    } catch {
+      return null;
+    }
   }
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -6,5 +6,15 @@
   "next": "Next",
   "software_developer": "I'm a Software Developer",
   "ai_passion": "Incorporating artificial intelligence systems into the products we use every day is my passion.",
-  "page_not_found": "Page not found!"
+  "page_not_found": "Page not found!",
+  "webgl_ball_demo": "WebGL Ball Demo",
+  "webgl_ball_unavailable": "This browser or environment does not provide a usable WebGL context for the demo.",
+  "back_home": "Back home",
+  "personal_info_public_bio": "I'm a curious and energetic person. I split my time between work, training, and enjoying video games. Solo travel lets me observe how things work in different places, always with my cat and good friends close to heart.",
+  "personal_info_toggle": "Private notes",
+  "personal_info_token_label": "Access token",
+  "personal_info_token_placeholder": "Enter a token to load private notes",
+  "personal_info_load": "Load private notes",
+  "personal_info_clear": "Clear token",
+  "personal_info_load_failed": "Could not load personal info"
 }

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -6,5 +6,15 @@
   "next": "Siguiente",
   "software_developer": "Soy desarrollador de software",
   "ai_passion": "Incorporar sistemas de inteligencia artificial en los productos que usamos a diario es mi pasi\u00F3n.",
-  "page_not_found": "\u00A1P\u00E1gina no encontrada!"
+  "page_not_found": "\u00A1P\u00E1gina no encontrada!",
+  "webgl_ball_demo": "Demo de esfera WebGL",
+  "webgl_ball_unavailable": "Este navegador o entorno no ofrece un contexto WebGL utilizable para la demo.",
+  "back_home": "Volver al inicio",
+  "personal_info_public_bio": "Soy una persona curiosa y en\u00E9rgica. Reparto mi tiempo entre trabajar, entrenar y disfrutar de los videojuegos. Viajar solo me permite observar c\u00F3mo funcionan las cosas en distintos lugares, siempre acompa\u00F1ado de mi gato y buenos amigos.",
+  "personal_info_toggle": "Notas privadas",
+  "personal_info_token_label": "Token de acceso",
+  "personal_info_token_placeholder": "Ingresa un token para cargar notas privadas",
+  "personal_info_load": "Cargar notas privadas",
+  "personal_info_clear": "Borrar token",
+  "personal_info_load_failed": "No se pudo cargar la informaci\u00F3n personal"
 }


### PR DESCRIPTION
## Summary
- follow up on the review comments from #361
- harden the personal info flow with config validation, a visible token control, bearer auth, and localized copy
- add a graceful WebGL fallback with BallComponent coverage, fix the console degree wording, and remove the unused karma coverage reporter

## Verification
- `npm run lint`
- `npm run build`
- `CHROME_BIN=$(command -v google-chrome-stable || command -v google-chrome) npm run test:dryrun`

## QA
- hosted preview check pending

## Non-blocking follow-ups
- `/projects` is still empty on `develop`; this branch does not change that route

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * WebGL Ball Demo displays a fallback error message and navigation link when WebGL is unavailable
  * Added personal info feature with token-based authentication to access private notes

* **Documentation**
  * Updated setup instructions with security guidelines for token handling

* **Localization**
  * Added English and Spanish translations for WebGL demo and personal info features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->